### PR TITLE
Add Docker build and fix GOPROXY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,5 @@ FROM ubuntu:22.04 AS builder
 RUN apt-get update && apt-get install -y git curl make bash
 WORKDIR /workspace
 COPY . .
-RUN bash src/build.sh osmosis
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:22.04 AS builder
+RUN apt-get update && apt-get install -y git curl make bash
+WORKDIR /workspace
+COPY . .
+RUN bash src/build.sh osmosis
+
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Osmosis Launcher is a wrapper for [osmosis](https://github.com/osmosis-labs/osmo
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
+- [Build with Docker](#build-with-docker)
 - [Scripts Details](#scripts-details)
 - [Contributing](#contributing)
 - [License](#license)
@@ -74,6 +75,16 @@ This is equivalent to:
 ```console
 ./osmosisd optionalArg1 optionalArg2 ...
 ```
+
+## Build with Docker
+An alternative to installing Go locally is to use Docker:
+
+```console
+./docker_build.sh
+```
+This script builds an image for the current platform and runs it with `--rm` so
+the container is removed once the build is over. The resulting `osmosisd`
+binary is copied back to the project root.
 
 ## Scripts Details
 - **src/clone.sh**: Clone the Osmosis repo at a given tag into the `osmosis` folder.

--- a/README.md
+++ b/README.md
@@ -80,16 +80,17 @@ This is equivalent to:
 An alternative to installing Go locally is to use Docker:
 
 ```console
-./docker_build.sh
+./docker_make.sh [tag]
 ```
-This script builds an image for the current platform and runs it with `--rm` so
-the container is removed once the build is over. The resulting `osmosisd`
-binary is copied back to the project root.
+This script builds an image for the current platform, runs `src/make.sh` inside
+the container with `--rm`, and copies the resulting `osmosisd` binary back to
+the project root. The version of the binary is checked after the build.
 
 ## Scripts Details
 - **src/clone.sh**: Clone the Osmosis repo at a given tag into the `osmosis` folder.
 - **src/patch.sh**: Apply the patch to enable launcher mode in osmosisd.
 - **src/make.sh**: Build the modified Osmosis sources.
+- **docker_make.sh**: Build the patched binary using Docker.
 - **src/build.sh**: Advanced build for different environments.
 - **src/tags.sh**: List available tags from the Osmosis repo.
 - **src/last_tag.sh**: Show the latest available tag.

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Build osmosisd inside a Docker container matching the host architecture
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+
+docker build --platform="$ARCH" -t osmosis-launcher-build "$SCRIPT_DIR"
+# Copy the resulting binary back to the host
+docker run --rm -v "$PWD":/output osmosis-launcher-build \
+  cp /workspace/osmosisd /output/
+
+echo "[OK] osmosisd built in $(pwd)/osmosisd"

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -5,8 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
 
 docker build --platform="$ARCH" -t osmosis-launcher-build "$SCRIPT_DIR"
-# Copy the resulting binary back to the host
+# Build inside the container and copy the resulting binary back to the host
 docker run --rm -v "$PWD":/output osmosis-launcher-build \
-  cp /workspace/osmosisd /output/
+  bash -c "cd /workspace && src/build.sh osmosis && cp osmosisd /output/"
 
 echo "[OK] osmosisd built in $(pwd)/osmosisd"

--- a/docker_make.sh
+++ b/docker_make.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Build patched osmosisd using Docker and src/make.sh
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TAG="${1-}"
+ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+
+# Build the image for the host architecture
+docker build --platform="$ARCH" -t osmosis-launcher-build "$SCRIPT_DIR"
+
+# Run make.sh inside the container and copy the result back
+if [ -n "$TAG" ]; then
+  BUILD_CMD="cd /workspace && src/make.sh $TAG && cp osmosisd /output/"
+else
+  BUILD_CMD="cd /workspace && src/make.sh && cp osmosisd /output/"
+fi
+
+docker run --rm -v "$PWD":/output osmosis-launcher-build bash -c "$BUILD_CMD"
+
+# Verify the built binary
+if [ ! -f osmosisd ]; then
+  echo "[FAIL] osmosisd binary not found after Docker build."
+  exit 1
+fi
+BUILT_VERSION=$(./osmosisd version 2>/dev/null | head -n 1)
+if [ -n "$TAG" ]; then
+  TAG_CLEANED=${TAG#v}
+  if [ "$BUILT_VERSION" != "$TAG_CLEANED" ]; then
+    echo "[FAIL] osmosisd version ($BUILT_VERSION) does not match tag ($TAG_CLEANED)."
+    exit 1
+  fi
+fi
+
+echo "[OK] osmosisd built with version: $BUILT_VERSION"

--- a/src/build.sh
+++ b/src/build.sh
@@ -84,6 +84,7 @@ trap cleanup EXIT
 
 # Compiler le binaire pour la plateforme courante
 pushd "$TARGET_DIR"
+export GOPROXY=direct
 echo "[INFO] Compilation du binaire osmosisd pour $(go env GOOS)/$(go env GOARCH) ..."
 make build
 popd

--- a/tests/test_08_docker_make.sh
+++ b/tests/test_08_docker_make.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Test script for docker_make.sh
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DOCKER_MAKE_SH="$SCRIPT_DIR/../docker_make.sh"
+FORMAT_TITLE_SH="$SCRIPT_DIR/../src/format_title.sh"
+
+echo_title() {
+  bash "$FORMAT_TITLE_SH" "$(basename "$0")"
+}
+
+cleanup() {
+  rm -f osmosisd
+}
+
+trap 'echo_title; cleanup' EXIT
+
+echo_title
+
+echo "[INFO] Test docker_make"
+
+# Skip if docker is not available
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[SKIP] Docker command not found. Skipping docker_make test."
+  exit 0
+fi
+
+# Attempt to build without specifying a tag (uses last tag)
+if ! bash "$DOCKER_MAKE_SH"; then
+  echo "[FAIL] docker_make.sh failed"
+  exit 1
+fi
+
+if [ ! -f osmosisd ]; then
+  echo "[FAIL] osmosisd binary not found after docker_make.sh"
+  exit 1
+fi
+
+# Basic check of the produced version
+BUILT_VERSION=$(./osmosisd version 2>/dev/null | head -n 1)
+if [ -z "$BUILT_VERSION" ]; then
+  echo "[FAIL] Unable to read osmosisd version"
+  exit 1
+fi
+
+echo "[OK] docker_make built osmosisd version $BUILT_VERSION"


### PR DESCRIPTION
## Summary
- add a Dockerfile for containerized builds
- add helper script `docker_build.sh`
- document Docker workflow in README
- export `GOPROXY=direct` in build script for restricted networks

## Testing
- `tests/test_01_tags.sh`
- `tests/test_02_last_tag.sh`
- `tests/test_03_clone.sh`
- `tests/test_04_download_go_archive.sh`
- `tests/test_05_build.sh` *(fails: network access to gotest.tools, storage.googleapis.com blocked)*
- `tests/test_06_patch.sh` *(fails: network access to storage.googleapis.com blocked)*
- `tests/test_07_make.sh` *(fails: network access to storage.googleapis.com blocked)*


------
https://chatgpt.com/codex/tasks/task_e_68540d4df8c4832bb4753ef78f9e1232